### PR TITLE
fixed autobinding of persistence context

### DIFF
--- a/grails-app/services/grails/plugins/jesque/JesqueService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueService.groovy
@@ -168,7 +168,8 @@ class JesqueService implements DisposableBean {
 		Admin admin = new AdminImpl(jesqueConfig)
 		admin.setWorker(worker)
 
-		def workerPersistenceListener = new WorkerPersistenceListener(persistenceInterceptor)
+		def autoFlush = grailsApplication.config.grails.jesque.autoFlush ?: true
+		def workerPersistenceListener = new WorkerPersistenceListener(persistenceInterceptor, autoFlush)
 		worker.getWorkerEventEmitter().addListener(workerPersistenceListener, WorkerEvent.JOB_EXECUTE, WorkerEvent.JOB_SUCCESS, WorkerEvent.JOB_FAILURE)
 
 		def workerLifeCycleListener = new WorkerLifecycleListener(this)

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ grails:
         schedulerThreadActive: true
         delayedJobThreadActive: true
         startPaused: false
+        autoFlush: true
         workers:
             DemoJesqueJobPool:
                 queueNames: DemoJesqueJobQueue
@@ -187,6 +188,7 @@ Release Notes
 * 1.0.6 - Background the starting of the jobs to speed up booting
 * 1.1.0 - Adding sentinel support
 * 1.1.2 - Bug fix for wiring jobs
+* 1.1.3 - Bug fix for worker persistence context
 
 
 License

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Release Notes
 * 1.0.6 - Background the starting of the jobs to speed up booting
 * 1.1.0 - Adding sentinel support
 * 1.1.2 - Bug fix for wiring jobs
-* 1.1.3 - Bug fix for worker persistence context
+* 1.1.4 - Bug fix for worker persistence context
 
 
 License


### PR DESCRIPTION
somewhere in the original plugin a bug was introduced that has never been released which basicly made it impossible to bind a persistence context to the worker thread.
With that new implementation of the WorkerPersistenceListener the bug should be fixed and the it is configurable whether or not the session should be automaticly flushed after a job finishes.