### PR TITLE
cleanup of transactional and scope settings in services

### DIFF
--- a/grails-app/services/grails/plugins/jesque/JesqueDelayedJobService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueDelayedJobService.groovy
@@ -8,8 +8,6 @@ import redis.clients.jedis.Pipeline
 
 class JesqueDelayedJobService {
 
-    static transactional = false
-
     def redisService
     def jesqueService
 

--- a/grails-app/services/grails/plugins/jesque/JesqueDelayedJobThreadService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueDelayedJobThreadService.groovy
@@ -6,8 +6,6 @@ import org.springframework.beans.factory.DisposableBean
 import java.util.concurrent.atomic.AtomicReference
 
 class JesqueDelayedJobThreadService implements Runnable, DisposableBean {
-    static transactional = true
-    static scope = 'singleton'
 
     protected static final Integer IDLE_WAIT_TIME = 10 * 1000
     protected AtomicReference<JesqueDelayedJobThreadState> threadState = new AtomicReference(JesqueDelayedJobThreadState.New)

--- a/grails-app/services/grails/plugins/jesque/JesqueSchedulerService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueSchedulerService.groovy
@@ -14,7 +14,6 @@ import redis.clients.jedis.Tuple
 
 @Slf4j
 class JesqueSchedulerService {
-    static transactional = false
 
     RedisService redisService
     GrailsApplication grailsApplication

--- a/grails-app/services/grails/plugins/jesque/JesqueSchedulerThreadService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueSchedulerThreadService.groovy
@@ -7,9 +7,6 @@ import java.util.concurrent.atomic.AtomicReference
 
 class JesqueSchedulerThreadService implements Runnable, DisposableBean {
 
-    static transactional = true
-    static scope = 'singleton'
-
     protected static String hostName
     protected static final Integer IDLE_WAIT_TIME = 10 * 1000
     protected AtomicReference<JesqueScheduleThreadState> threadState = new AtomicReference(JesqueScheduleThreadState.New)

--- a/grails-app/services/grails/plugins/jesque/JesqueService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueService.groovy
@@ -19,9 +19,6 @@ import org.springframework.beans.factory.DisposableBean
 @Slf4j
 class JesqueService implements DisposableBean {
 
-    static transactional = false
-    static scope = 'singleton'
-
     static final int DEFAULT_WORKER_POOL_SIZE = 3
 
     GrailsApplication grailsApplication


### PR DESCRIPTION
The transactional and scope settings are pretty outdated.
In the end, all services are non-transactional by default in grails 3, so it makes no sense to have transactional field in the service.
Also, the default scope for services is "singleton", so we can get rid of this field as well.