### PR TITLE
allow listeners to implement GrailsApplicationAware

### DIFF
--- a/grails-app/services/grails/plugins/jesque/JesqueService.groovy
+++ b/grails-app/services/grails/plugins/jesque/JesqueService.groovy
@@ -1,6 +1,7 @@
 package grails.plugins.jesque
 
 import grails.core.GrailsApplication
+import grails.core.support.GrailsApplicationAware
 import grails.persistence.support.PersistenceContextInterceptor
 import groovy.util.logging.Slf4j
 import net.greghaines.jesque.Job
@@ -308,7 +309,11 @@ class JesqueService implements DisposableBean {
             }
         }
         if (customListenerClass && customListenerClass in WorkerListener) {
-            worker.workerEventEmitter.addListener(customListenerClass.newInstance() as WorkerListener)
+            def customListener = customListenerClass.newInstance() as WorkerListener
+            if (customListener instanceof GrailsApplicationAware) {
+                customListener.setGrailsApplication(grailsApplication)
+            }
+            worker.workerEventEmitter.addListener(customListener)
         } else if (customListenerClass) {
             // the "null" case should only happen at this point, when we could not find the class, so we can safely assume there was a error message already
             log.warn("The specified custom listener class ${customListenerClass} does not implement WorkerListener. Ignoring it")

--- a/readme.md
+++ b/readme.md
@@ -141,17 +141,19 @@ class DemoJesqueJob {
 
 Custom Worker Listener
 ----
-You can define one or more custom WorkerListener classes that will be automaticly added to all workers started from within jesqueService
+You can define one or more custom WorkerListener classes that will be automatically added to all workers started from within `jesqueService`.
+You can implement the `GrailsApplicationAware` interface if you need access to the `grailsApplication` in your worker listener.
+
 ```groovy
 grails {
     jesque {
-        }
         custom {
-            listener.clazz = [LoggingWorkerListener] // accepts String, Class or List of String or Class
+            listener.clazz = [LoggingWorkerListener] // accepts String, Class or List<String> or List<Class>
         }
     }
 }
 ```
+ 
 *All Listeners have to implement the WorkerListener Interface otherwise they will simply be ignored*
 
 Roadmap


### PR DESCRIPTION
If a custom worker listener implements the GrailsApplicationAware interface, we pass the grailsApplication to it.
This allows the use of beans (e.g. services) in worker listeners.